### PR TITLE
feat: added hover transition lightbulb in text

### DIFF
--- a/docs/assets/cheatsheets/cheatsheets.css
+++ b/docs/assets/cheatsheets/cheatsheets.css
@@ -8,6 +8,14 @@ svg.dropdown_icon:hover {
     fill: yellow;
 }
 
+span.lightbulb {
+    transition: 0.3s;
+}
+
+span.lightbulb:hover {
+    color: #FFD700;
+}
+
 .dropdown_container {
     display: flex;
     /* float: right; */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,7 +102,7 @@ extra:
     folder: ':fontawesome-regular-folder:'
     github: ':fontawesome-brands-github:'
     L: '└──'
-    lightbulb: ':fontawesome-regular-lightbulb:'
+    lightbulb: '<span class="lightbulb">:fontawesome-regular-lightbulb:</span>'
     new_file: '<span style="color: green;">:fontawesome-regular-file-code:</span>'
     new_file_lines: '<span style="color: green;">:fontawesome-regular-file-lines:</span>'
     new_folder: '<span style="color: green;">:fontawesome-regular-folder:</span>'


### PR DESCRIPTION
Ik heb het hoverevent wat we gebruiken voor de cheatsheets nu ook toegevoegd aan de lightbulbs die in de tekst staan, alleen nu met een wat donkere kleur geel, omdat het lichtgeel iets te hard vloekte met de witte achtergrond van de tekst. We kunnen hem nog meer oranje maken als dat nodig is.
Mij leek het wel leuk als de lightbulbs in de tekst ook interactief waren.